### PR TITLE
Add GGUF model loading path for OmniTag processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,6 @@ Perfect for building high-quality LoRA datasets, especially when you want **raw,
 
 
 
-Works with 4-bit quantized Qwen3-VL-8B (≈10–14 GB VRAM)  
-First run downloads model automatically (~16 GB)
+Now defaults to loading the GGUF build (`Qwen3-VL-8B-Abliterated-Caption-it.Q8_0.gguf`) from `prithivMLmods/Qwen3-VL-8B-Abliterated-Caption-it-GGUF`.  
+You can still switch `model_id` to a Transformers repo if needed.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ bitsandbytes
 openai-whisper
 pillow
 numpy
+llama-cpp-python


### PR DESCRIPTION
### Motivation
- Enable the processor to load the GGUF build you supplied and prefer a GGUF-first workflow while preserving the existing Transformers loading path as a fallback. 
- Allow users to provide either a Hugging Face repo id, a full HF blob URL, or a local `.gguf` path for flexible model loading.

### Description
- Added GGUF backend support using `llama-cpp-python` with repo/URL parsing and HF download via `hf_hub_download`, plus imports for `io`, `base64`, and `urllib.parse` to support image encoding and URL parsing. 
- Introduced `_parse_hf_url`, `_encode_pil_to_data_url`, and `_load_model` helpers and a `backend` selector to load either a local `.gguf`, a GGUF from a HF repo (using `gguf_filename`), or fall back to the Transformers `Qwen3VLForConditionalGeneration` path with the existing BitsAndBytes config. 
- Changed node inputs to default to the GGUF target by adding `gguf_filename` and updating `model_id` default to `prithivMLmods/Qwen3-VL-8B-Abliterated-Caption-it-GGUF`, and updated `install_dependencies` and `requirements.txt` to include `llama-cpp-python`. 
- Updated `generate_caption` to handle GGUF chat completion calls (image encoded as data URL) while keeping the original Transformers multimodal generation flow intact, and added a short README note about the new default behavior.

### Testing
- Ran `python -m py_compile __init__.py` to verify the module compiles successfully and the code changes are syntactically valid (compilation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ebe7b214832f9c417a093718a537)