### PR TITLE
Accept external GGUF model input and remove custom loader node

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Say hello to **uncensored clinical detail** powered by **Qwen3-VL-8B-Abliterated
 1. Right-click your folder/video in File Explorer  
 2. Choose **Copy as path**  
 3. Click the text field in OmniTag → Ctrl+V to paste  
-4. Press Queue Prompt → get PNGs/MP4s + perfect .txt captions ready for training!
+4. Load your model with your preferred loader (for GGUF, use the existing **ComfyUI-GGUF** model loader node)
+5. Connect that model output into **SeansOmniTagProcessor**
+6. Set `processor_id` to the matching Hugging Face processor (default: `Qwen/Qwen2.5-VL-7B-Instruct`)
+7. Press Queue Prompt → get PNGs/MP4s + perfect .txt captions ready for training!
 
 🖼️📁 **Batch Folder Mode**  
 → Throw any folder at it (images + videos mixed)  
@@ -54,5 +57,5 @@ Perfect for building high-quality LoRA datasets, especially when you want **raw,
 
 
 Works with 4-bit quantized Qwen3-VL-8B (≈10–14 GB VRAM)  
-First run downloads model automatically (~16 GB)
+Model is now provided as an input, so you can reuse models loaded by other nodes (including GGUF workflows).
 


### PR DESCRIPTION
### Motivation
- Allow users to wire in models loaded by existing nodes (e.g. ComfyUI-GGUF) instead of forcing a custom loader node. 
- Make the processor agnostic to model ownership so the same model instance can be reused across nodes and workflows. 
- Provide a separate `processor_id` so the HF processor/template can be chosen independently of the model loader.

### Description
- Removed the dedicated `SeansOmniTagModelLoader` and `SeansOmniTagModelBundle` classes and left a single `SeansOmniTagProcessor` node in `NODE_CLASS_MAPPINGS`.
- Updated `SeansOmniTagProcessor.INPUT_TYPES` to accept a generic external `model` input (`"*"`) and added a `processor_id` string input with a default HF processor ID.
- Added a `resolve_model` helper that finds a usable model exposing `.generate(...)` from direct objects, tuples/lists, or common dict keys, and added clear error messages when the connected object is incompatible.
- Switched `generate_caption` to accept `(model, processor, device, ...)` and load the processor via `AutoProcessor.from_pretrained(kwargs.get("processor_id"))`, while removing the prior internal heavy model-loading logic and 4-bit config imports.
- Updated README instructions to document using an existing model loader (including GGUF) and setting `processor_id` accordingly.

### Testing
- Ran `python -m py_compile __init__.py` to verify bytecode compilation, which completed successfully.
- Ran an additional runtime compile check via `compile(Path('__init__.py').read_text(), '__init__.py', 'exec')` which returned syntax OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991f34f4dc8832f8af53d53fcbffee8)